### PR TITLE
Add groups in runtime

### DIFF
--- a/.changeset/khaki-buckets-happen.md
+++ b/.changeset/khaki-buckets-happen.md
@@ -1,0 +1,5 @@
+---
+"effect-http": patch
+---
+
+add real groups for storing options used in openapi generation

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 build/
 docs/
 .direnv/
+.idea

--- a/examples/groups.ts
+++ b/examples/groups.ts
@@ -7,11 +7,22 @@ import { debugLogger } from "./_utils.js"
 
 const responseSchema = Schema.struct({ name: Schema.string })
 
-const testApi = Api.apiGroup("test").pipe(
+const testApi = Api.apiGroup("test", {
+  description: "Test description",
+  externalDocs: {
+    description: "Test external doc",
+    url: "https://www.google.com/search?q=effect-http"
+  }
+}).pipe(
   Api.get("test", "/test", { response: responseSchema })
 )
 
-const userApi = Api.apiGroup("Users").pipe(
+const userApi = Api.apiGroup("Users", {
+  description: "All about users",
+  externalDocs: {
+    description: "No documentation :("
+  }
+}).pipe(
   Api.get("getUser", "/user", { response: responseSchema }),
   Api.post("storeUser", "/user", { response: responseSchema }),
   Api.put("updateUser", "/user", { response: responseSchema }),

--- a/examples/groups.ts
+++ b/examples/groups.ts
@@ -20,7 +20,7 @@ const testApi = Api.apiGroup("test", {
 const userApi = Api.apiGroup("Users", {
   description: "All about users",
   externalDocs: {
-    description: "No documentation :("
+    url: "https://www.google.com/search?q=effect-http"
   }
 }).pipe(
   Api.get("getUser", "/user", { response: responseSchema }),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build-annotate": "babel build --plugins annotate-pure-calls --out-dir build --source-maps",
     "clean": "rimraf build dist coverage .tsbuildinfo",
     "check": "tsc -b tsconfig.json",
+    "check:watch": "tsc -b tsconfig.json --watch",
     "test": "vitest",
     "coverage": "vitest --run --coverage related",
     "coverage-all": "vitest --run --coverage",

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -47,7 +47,7 @@ export type ApiGroupTypeId = typeof ApiGroupTypeId
  */
 export interface Api<E extends Endpoint = Endpoint> extends Pipeable.Pipeable {
   [ApiTypeId]: ApiTypeId
-  endpoints: Array<E>
+  groups: Array<ApiGroup<E>>
   options: {
     title: string
     version: string
@@ -66,7 +66,14 @@ export interface Api<E extends Endpoint = Endpoint> extends Pipeable.Pipeable {
 export interface ApiGroup<E extends Endpoint = Endpoint> extends Pipeable.Pipeable {
   [ApiGroupTypeId]: ApiGroupTypeId
   endpoints: Array<E>
-  groupName: string
+  options: {
+    name: string
+    description?: string
+    externalDocs?: {
+      description: string
+      url?: string
+    }
+  }
 }
 
 /**
@@ -224,7 +231,8 @@ export const options: EndpointSetter = internal.endpoint("options")
  * @category constructors
  * @since 1.0.0
  */
-export const apiGroup: (groupName: string) => ApiGroup<never> = internal.apiGroup
+export const apiGroup: (name: string, options?: Omit<ApiGroup["options"], "name">) => ApiGroup<never> =
+  internal.apiGroup
 
 /**
  * Merge the Api `Group` with an `Api`
@@ -242,11 +250,11 @@ export const addGroup: <E2 extends Endpoint>(
  */
 export const getEndpoint: <
   A extends Api,
-  Id extends A["endpoints"][number]["id"]
+  Id extends A["groups"][number]["endpoints"][number]["id"]
 >(
   api: A,
   id: Id
-) => Extract<A["endpoints"][number], { id: Id }> = internal.getEndpoint
+) => Extract<A["groups"][number]["endpoints"][number], { id: Id }> = internal.getEndpoint
 
 /**
  * FormData schema

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -70,8 +70,8 @@ export interface ApiGroup<E extends Endpoint = Endpoint> extends Pipeable.Pipeab
     name: string
     description?: string
     externalDocs?: {
-      description: string
-      url?: string
+      description?: string
+      url: string
     }
   }
 }

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -98,9 +98,7 @@ export interface Endpoint {
   path: PlatformRouter.PathInput
   method: Method
   schemas: EndpointSchemas
-  options: EndpointOptions & {
-    groupName: string
-  }
+  options: EndpointOptions
 }
 
 /**

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -91,8 +91,11 @@ export interface Endpoint {
   path: PlatformRouter.PathInput
   method: Method
   schemas: EndpointSchemas
-  groupName: string
-  description?: string
+  options: {
+    groupName: string
+    description?: string
+    summary?: string
+  }
 }
 
 /**
@@ -153,6 +156,7 @@ export const api: (options?: Partial<Api["options"]>) => Api<never> = internal.a
  */
 export interface EndpointOptions {
   description?: string
+  summary?: string
 }
 
 /**
@@ -359,6 +363,9 @@ type CreateEndpointFromInput<
   schemas: CreateEndpointSchemasFromInput<Schemas>
   path: PlatformRouter.PathInput
   method: Method
-  groupName: string
-  description?: string
+  options: {
+    groupName: string
+    description?: string
+    summary?: string
+  }
 }

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -43,12 +43,12 @@ export const fromEndpoint: <Endpoint extends Api.Endpoint, R, E>(
  */
 export const make: <
   A extends Api.Api,
-  Id extends A["endpoints"][number]["id"],
+  Id extends A["groups"][number]["endpoints"][number]["id"],
   R,
   E
 >(
   id: Id,
-  fn: HandlerFunction<Extract<A["endpoints"][number], { id: Id }>, R, E>,
+  fn: HandlerFunction<Extract<A["groups"][number]["endpoints"][number], { id: Id }>, R, E>,
   options?: RouterBuilder.Options
 ) => (api: A) => Router.Route<R, Exclude<E, ServerError.ServerError>> = internal.make
 

--- a/src/RouterBuilder.ts
+++ b/src/RouterBuilder.ts
@@ -45,7 +45,7 @@ export interface Options {
 export const make: <Api extends Api.Api>(
   api: Api,
   options?: Partial<Options>
-) => RouterBuilder<never, never, Api["endpoints"][number]> = internal.make
+) => RouterBuilder<never, never, Api["groups"][number]["endpoints"][number]> = internal.make
 
 /**
  * Handle an endpoint using a raw `Router.Route.Handler`.

--- a/src/internal/api.ts
+++ b/src/internal/api.ts
@@ -134,15 +134,12 @@ export const endpoint = (method: Api.Method) =>
 
   checkPathPatternMatchesSchema(id, path, schemas.request?.params)
 
-  const newEndpoint = {
+  const newEndpoint: Api.Endpoint = {
     schemas: createSchemasFromInput(schemas),
     id,
     path,
     method,
-    options: {
-      ...options,
-      groupName: "groupName" in api ? api.groupName : "default"
-    }
+    options: options ?? {}
   }
 
   if (isApiGroup(api)) {
@@ -153,7 +150,6 @@ export const endpoint = (method: Api.Method) =>
   } else {
     const defaultGroup = api.groups.find((x) => x.options.name === "default") ?? apiGroup("default")
     const groupsWithoutDefault = api.groups.filter((x) => x.options.name !== "default")
-
     const newDefaultGroup = pipe(defaultGroup, endpoint(method)(id, path, schemas, options))
 
     return new ApiImpl(

--- a/src/internal/api.ts
+++ b/src/internal/api.ts
@@ -135,8 +135,10 @@ export const endpoint = (method: Api.Method) =>
     id,
     path,
     method,
-    groupName: "groupName" in api ? api.groupName : "default",
-    ...options
+    options: {
+      ...options,
+      groupName: "groupName" in api ? api.groupName : "default"
+    }
   }
 
   if (isApi(api)) {

--- a/src/internal/api.ts
+++ b/src/internal/api.ts
@@ -113,7 +113,11 @@ export const endpoint = (method: Api.Method) =>
     throw new Error(`Invalid ${id} endpoint. GET request cant have a body.`)
   }
 
-  if (api.endpoints.find((endpoint) => endpoint.id === id) !== undefined) {
+  if (isApiGroup(api) && api.endpoints.find((endpoint) => endpoint.id === id) !== undefined) {
+    throw new Error(`Endpoint with operation id ${id} already exists`)
+  }
+
+  if (isApi(api) && api.groups.find((group) => group.endpoints.find((endpoint) => endpoint.id === id)) !== undefined) {
     throw new Error(`Endpoint with operation id ${id} already exists`)
   }
 
@@ -141,14 +145,22 @@ export const endpoint = (method: Api.Method) =>
     }
   }
 
-  if (isApi(api)) {
-    return new ApiImpl([...api.endpoints, newEndpoint], api.options) as any
-  }
+  if (isApiGroup(api)) {
+    return new ApiGroupImpl(
+      [...api.endpoints, newEndpoint],
+      api.options
+    ) as any
+  } else {
+    const defaultGroup = api.groups.find((x) => x.options.name === "default") ?? apiGroup("default")
+    const groupsWithoutDefault = api.groups.filter((x) => x.options.name !== "default")
 
-  return new ApiGroupImpl(
-    [...api.endpoints, newEndpoint],
-    api.groupName
-  ) as any
+    const newDefaultGroup = pipe(defaultGroup, endpoint(method)(id, path, schemas, options))
+
+    return new ApiImpl(
+      [...groupsWithoutDefault, newDefaultGroup],
+      api.options
+    ) as any
+  }
 }
 
 /** Headers are case-insensitive, internally we deal with them as lowercase
@@ -180,16 +192,30 @@ const DEFAULT_OPTIONS: Api.Api["options"] = {
   version: "1.0.0"
 }
 
-export const apiGroup = (groupName: string): Api.ApiGroup<never> => new ApiGroupImpl([], groupName)
+export const apiGroup = (
+  name: Api.ApiGroup["options"]["name"],
+  options?: Omit<Api.ApiGroup["options"], "name">
+): Api.ApiGroup<never> => new ApiGroupImpl([], { name, ...options })
 
 export const getEndpoint = <
   A extends Api.Api,
-  Id extends A["endpoints"][number]["id"]
+  Id extends A["groups"][number]["endpoints"][number]["id"]
 >(
   api: A,
   id: Id
-): Extract<A["endpoints"][number], { id: Id }> => {
-  const endpoint = api.endpoints.find(({ id: _id }) => _id === id)
+): Extract<A["groups"][number]["endpoints"][number], { id: Id }> => {
+  let endpoint: Api.Endpoint | undefined = undefined
+
+  api.groups.find((g) =>
+    g.endpoints.find((e) => {
+      if (e.id === id) {
+        endpoint = e
+        return true
+      } else {
+        return false
+      }
+    })
+  )
 
   // This operation is type-safe and non-existing ids are forbidden
   if (endpoint === undefined) {
@@ -208,7 +234,7 @@ export const getEndpoint = <
 export const addGroup =
   <E2 extends Api.Endpoint>(apiGroup: Api.ApiGroup<E2>) =>
   <E1 extends Api.Endpoint>(api: Api.Api<E1>): Api.Api<E1 | E2> => {
-    const existingIds = HashSet.make(...api.endpoints.map(({ id }) => id))
+    const existingIds = HashSet.make(...api.groups.flatMap((x) => x.endpoints).map(({ id }) => id))
     const newIds = HashSet.make(...apiGroup.endpoints.map(({ id }) => id))
     const duplicates = HashSet.intersection(existingIds, newIds)
 
@@ -217,8 +243,9 @@ export const addGroup =
         `Api group introduces already existing operation ids: ${duplicates}`
       )
     }
+    const newGroups: Array<Api.ApiGroup<E1 | E2>> = [...api.groups, apiGroup]
 
-    return new ApiImpl([...api.endpoints, ...apiGroup.endpoints], api.options)
+    return new ApiImpl(newGroups, api.options)
   }
 
 export const api = (options?: Partial<Api.Api["options"]>): Api.Api<never> =>
@@ -246,13 +273,12 @@ export const IgnoredSchemaId: Api.IgnoredSchemaId = Symbol.for(
 
 /** @internal */
 class ApiImpl<Endpoints extends Api.Endpoint> implements Api.Api<Endpoints> {
-  readonly [ApiTypeId]: Api.ApiTypeId
+  readonly [ApiTypeId]: Api.ApiTypeId = ApiTypeId
 
   constructor(
-    readonly endpoints: Array<Endpoints>,
+    readonly groups: Array<Api.ApiGroup<Endpoints>>,
     readonly options: Api.Api["options"]
   ) {
-    this[ApiTypeId] = ApiTypeId
   }
 
   pipe() {
@@ -263,13 +289,12 @@ class ApiImpl<Endpoints extends Api.Endpoint> implements Api.Api<Endpoints> {
 
 /** @internal */
 class ApiGroupImpl<Endpoints extends Api.Endpoint> implements Api.ApiGroup<Endpoints> {
-  readonly [ApiGroupTypeId]: Api.ApiGroupTypeId
+  readonly [ApiGroupTypeId]: Api.ApiGroupTypeId = ApiGroupTypeId
 
   constructor(
     readonly endpoints: Array<Endpoints>,
-    readonly groupName: string
+    readonly options: Api.ApiGroup["options"]
   ) {
-    this[ApiGroupTypeId] = ApiGroupTypeId
   }
 
   pipe() {

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -50,7 +50,7 @@ export const make = <Endpoints extends Api.Endpoint>(
   api: Api.Api<Endpoints>,
   options?: Partial<Client.Options>
 ): Client.Client<Endpoints> =>
-  api.endpoints.reduce(
+  api.groups.flatMap((x) => x.endpoints).reduce(
     (client, endpoint) => ({
       ...client,
       [endpoint.id]: endpointClient(endpoint.id, api, options ?? {})

--- a/src/internal/mock-client.ts
+++ b/src/internal/mock-client.ts
@@ -12,7 +12,7 @@ export const make = <Endpoints extends Api.Endpoint>(
   api: Api.Api<Endpoints>,
   option?: Partial<MockClient.Options<Endpoints>>
 ): Client.Client<Endpoints> =>
-  api.endpoints.reduce((client, endpoint) => {
+  api.groups.flatMap((x) => x.endpoints).reduce((client, endpoint) => {
     const requestEncoder = ClientRequestEncoder.create(endpoint)
     const responseSchema = utils.createResponseSchema(
       endpoint.schemas.response

--- a/src/internal/open-api.ts
+++ b/src/internal/open-api.ts
@@ -10,7 +10,7 @@ export const make = (
   api: Api.Api
 ): SchemaOpenApi.OpenAPISpec<SchemaOpenApi.OpenAPISchemaType> => {
   const pathSpecs = api.endpoints.map(
-    ({ description, groupName, id, method, path, schemas }) => {
+    ({ id, method, options, path, schemas }) => {
       const operationSpec = []
 
       const responseSchema = schemas.response
@@ -65,8 +65,12 @@ export const make = (
         operationSpec.push(SchemaOpenApi.jsonRequest(body, descriptionSetter(body)))
       }
 
-      if (description) {
-        operationSpec.push(SchemaOpenApi.description(description))
+      if (options.description !== undefined) {
+        operationSpec.push(SchemaOpenApi.description(options.description))
+      }
+
+      if (options.summary !== undefined) {
+        operationSpec.push(SchemaOpenApi.summary(options.summary))
       }
 
       return SchemaOpenApi.path(
@@ -74,7 +78,7 @@ export const make = (
         SchemaOpenApi.operation(
           method,
           SchemaOpenApi.operationId(id),
-          SchemaOpenApi.tags(groupName),
+          SchemaOpenApi.tags(options.groupName),
           ...operationSpec
         )
       )

--- a/src/internal/open-api.ts
+++ b/src/internal/open-api.ts
@@ -10,9 +10,9 @@ export const make = (
   api: Api.Api
 ): SchemaOpenApi.OpenAPISpec<SchemaOpenApi.OpenAPISchemaType> => {
   const pathSpecs = api.groups.flatMap((g) =>
-      g.endpoints.map(
-    ({ id, method, options, path, schemas }) => {
-      const operationSpec = []
+    g.endpoints.map(
+      ({ id, method, options, path, schemas }) => {
+        const operationSpec = []
 
         const responseSchema = schemas.response
 
@@ -70,24 +70,25 @@ export const make = (
           operationSpec.push(SchemaOpenApi.description(options.description))
         }
 
-      if (options.summary !== undefined) {
-        operationSpec.push(SchemaOpenApi.summary(options.summary))
-      }
+        if (options.summary !== undefined) {
+          operationSpec.push(SchemaOpenApi.summary(options.summary))
+        }
 
-      if (options.deprecated) {
-        operationSpec.push(SchemaOpenApi.deprecated)
-      }
+        if (options.deprecated) {
+          operationSpec.push(SchemaOpenApi.deprecated)
+        }
 
-      return SchemaOpenApi.path(
-        createPath(path),
-        SchemaOpenApi.operation(
-          method,
-          SchemaOpenApi.operationId(id),
+        return SchemaOpenApi.path(
+          createPath(path),
+          SchemaOpenApi.operation(
+            method,
+            SchemaOpenApi.operationId(id),
             SchemaOpenApi.tags(g.options.name),
-          ...operationSpec
+            ...operationSpec
+          )
         )
-      )
-    }
+      }
+    )
   )
 
   const openApi = SchemaOpenApi.openAPI(

--- a/src/internal/open-api.ts
+++ b/src/internal/open-api.ts
@@ -4,6 +4,7 @@ import * as AST from "@effect/schema/AST"
 import * as Schema from "@effect/schema/Schema"
 import { identity, pipe } from "effect/Function"
 import * as Option from "effect/Option"
+import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Api from "../Api.js"
 
 export const make = (
@@ -90,6 +91,12 @@ export const make = (
       }
     )
   )
+
+  if (ReadonlyArray.isNonEmptyArray(api.groups)) {
+    const [firstGlobalTag, ...restGlobalTags] = ReadonlyArray.map(api.groups, (x) => x.options)
+
+    pathSpecs.push(SchemaOpenApi.globalTags(firstGlobalTag, ...restGlobalTags))
+  }
 
   const openApi = SchemaOpenApi.openAPI(
     api.options.title,

--- a/src/internal/route.ts
+++ b/src/internal/route.ts
@@ -60,12 +60,12 @@ export const fromEndpoint: <Endpoint extends Api.Endpoint, R, E>(
  */
 export const make: <
   A extends Api.Api,
-  Id extends A["endpoints"][number]["id"],
+  Id extends A["groups"][number]["endpoints"][number]["id"],
   R,
   E
 >(
   id: Id,
-  fn: Route.HandlerFunction<Extract<A["endpoints"][number], { id: Id }>, R, E>,
+  fn: Route.HandlerFunction<Extract<A["groups"][number]["endpoints"][number], { id: Id }>, R, E>,
   options?: RouterBuilder.Options
 ) => (api: A) => Router.Route<R, Exclude<E, ServerError.ServerError>> = (id, fn, options) => (api) => {
   const endpoint = Api.getEndpoint(api, id)

--- a/src/internal/router-builder.ts
+++ b/src/internal/router-builder.ts
@@ -20,8 +20,8 @@ const DEFAULT_OPTIONS: RouterBuilder.Options = {
 export const make = <A extends Api.Api>(
   api: A,
   options?: Partial<RouterBuilder.Options>
-): RouterBuilder.RouterBuilder<never, never, A["endpoints"][number]> => ({
-  remainingEndpoints: api.endpoints,
+): RouterBuilder.RouterBuilder<never, never, A["groups"][number]["endpoints"][number]> => ({
+  remainingEndpoints: api.groups.flatMap((x) => x.endpoints),
   router: Router.empty,
   api,
   options: { ...DEFAULT_OPTIONS, ...options },

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -5,7 +5,8 @@ import { expect, test } from "vitest"
 import { simpleApi1 } from "./example-apis.js"
 
 test("fillDefaultSchemas", () => {
-  expect(simpleApi1.endpoints).toHaveLength(1)
+  expect(simpleApi1.groups).toHaveLength(1)
+  expect(simpleApi1.groups.flatMap((x) => x.endpoints)).toHaveLength(1)
 })
 
 test("Attempt to declare duplicate operation id should fail as a safe guard", () => {


### PR DESCRIPTION
Now Api consist of groups, and group consist of endpoints
Groups are used for storing options for open-api's globalTags
Endpoints in scope of api end up in to default group