### PR TITLE
Align client response types according runtime 

### DIFF
--- a/.changeset/moody-dancers-love.md
+++ b/.changeset/moody-dancers-love.md
@@ -1,0 +1,5 @@
+---
+"effect-http": patch
+---
+
+filter out non 100-299 statuses from success channel

--- a/packages/effect-http-node/examples/100-299_success-channel.ts
+++ b/packages/effect-http-node/examples/100-299_success-channel.ts
@@ -1,0 +1,22 @@
+import { Schema } from "@effect/schema"
+import { Effect } from "effect"
+import { Api, Client } from "effect-http"
+
+export const api = Api.api().pipe(
+  Api.post("test", "/test", {
+    response: [{
+      status: 400
+    }, {
+      status: 200,
+      content: Schema.string
+    }]
+  })
+)
+
+const client = Client.make(api)
+
+const log200 = (answer: { status: 200 }) => Effect.log(answer)
+
+client
+  .test()
+  .pipe(Effect.tap(log200))

--- a/packages/effect-http/src/Route.ts
+++ b/packages/effect-http/src/Route.ts
@@ -64,19 +64,19 @@ type EndpointResponseSchemaTo<S> = S extends Api.IgnoredSchemaId ? void :
   : never
 
 /** @ignore */
-export type ResponseSchemaFullTo<S extends Api.ResponseSchemaFull> = S extends any ? Types.Simplify<
-    & {
-      status: S["status"]
-    }
-    & {
-      [
-        K in Exclude<
-          RequiredFields<S>,
-          "status" | "representations"
-        >
-      ]: S[K] extends Schema.Schema<any, any> ? utils.SchemaTo<S[K]> : never
-    }
-  >
+export type ResponseSchemaFullTo<S extends Api.ResponseSchemaFull> = S extends any ?
+  `${S["status"]}` extends `${1 | 2}${string}` ? Types.Simplify<
+      & { status: S["status"] }
+      & {
+        [
+          K in Exclude<
+            RequiredFields<S>,
+            "status" | "representations"
+          >
+        ]: S[K] extends Schema.Schema<any, any> ? utils.SchemaTo<S[K]> : never
+      }
+    >
+  : never
   : never
 
 /** @ignore */


### PR DESCRIPTION
Filter out non `1xx-2xx` statuses from success channel of server response in type level