### PR TITLE
feat: expose ClientError statuses derived from API

### DIFF
--- a/packages/effect-http/src/Client.ts
+++ b/packages/effect-http/src/Client.ts
@@ -140,11 +140,18 @@ export type ToRequest<
 }>
 
 /** @ignore */
+export type ClientFunctionError<
+  R extends ApiResponse.ApiResponse.Any
+> = [ApiResponse.ApiResponse.Status<utils.Filter200Responses<R>>] extends [infer S extends number]
+  ? ClientError.ClientError<S>
+  : ClientError.ClientError
+
+/** @ignore */
 export type EndpointClient<E extends ApiEndpoint.ApiEndpoint.Any> = (
   input: ToRequest<ApiEndpoint.ApiEndpoint.Request<E>>,
   map?: (request: HttpClient.request.ClientRequest) => HttpClient.request.ClientRequest
 ) => Effect.Effect<
   ClientFunctionResponse<ApiEndpoint.ApiEndpoint.Response<E>>,
-  ClientError.ClientError,
+  ClientFunctionError<ApiEndpoint.ApiEndpoint.Response<E>>,
   ApiEndpoint.ApiEndpoint.Context<E>
 >

--- a/packages/effect-http/src/internal/utils.ts
+++ b/packages/effect-http/src/internal/utils.ts
@@ -61,6 +61,10 @@ export type FilterNon200Responses<R extends ApiResponse.ApiResponse.Any> = R ext
   `${ApiResponse.ApiResponse.Status<R>}` extends `2${string}` ? R : never :
   never
 
+export type Filter200Responses<R extends ApiResponse.ApiResponse.Any> = R extends any ?
+  `${ApiResponse.ApiResponse.Status<R>}` extends `2${string}` ? never : R :
+  never
+
 export type NeedsFullResponse<R extends ApiResponse.ApiResponse.Any> = ApiResponse.ApiResponse.Headers<R> extends
   ApiSchema.Ignored ? false : true
 


### PR DESCRIPTION
Extracts all of the non-200 statuses from an Endpoint to be utilized in the returned `ClientError` when possible.