### PR TITLE
Request body should be required by default

### DIFF
--- a/.changeset/angry-windows-fold.md
+++ b/.changeset/angry-windows-fold.md
@@ -1,0 +1,5 @@
+---
+"effect-http": patch
+---
+
+Request body should be required by default

--- a/packages/effect-http/src/internal/open-api.ts
+++ b/packages/effect-http/src/internal/open-api.ts
@@ -69,7 +69,7 @@ export const make = (
         }
 
         if (!ApiSchema.isIgnored(body)) {
-          operationSpec.push(OpenApi.jsonRequest(body, descriptionSetter(body)))
+          operationSpec.push(OpenApi.jsonRequest(body, OpenApi.required, descriptionSetter(body)))
         }
 
         const securityResult = pipe(

--- a/packages/effect-http/test/openapi.test.ts
+++ b/packages/effect-http/test/openapi.test.ts
@@ -204,6 +204,39 @@ test("group info", () => {
   })
 })
 
+test("request body", () => {
+  const api = pipe(
+    Api.make(),
+    Api.addEndpoint(
+      Api.post("myOperation", "/my-operation").pipe(
+        Api.setRequestBody(Schema.Struct({ a: Schema.String }))
+      )
+    )
+  )
+
+  const openApi = OpenApi.make(api)
+
+  expect(openApi.paths["/my-operation"].post?.requestBody).toEqual({
+    content: {
+      "application/json": {
+        schema: {
+          properties: {
+            a: {
+              "description": "a string",
+              "type": "string"
+            }
+          },
+          required: [
+            "a"
+          ],
+          type: "object"
+        }
+      }
+    },
+    required: true
+  })
+})
+
 test("union in query params", () => {
   const api = pipe(
     Api.make(),


### PR DESCRIPTION
When using `Api.setRequestBody`, the body is optional. There is no way to mark it as required.

The API could be changed for something like that?
```
Api.setRequestBody(schema, { required: true })
```

It sounds to me that the expected user behavior should be required by default. I made a change accordingly.

I can also refine the `setRequestBody` method to add an option param if you like the idea.