### PR TITLE
Bug fix: RouterBuilder.handle type-params order

### DIFF
--- a/.changeset/loud-fishes-float.md
+++ b/.changeset/loud-fishes-float.md
@@ -1,0 +1,5 @@
+---
+"effect-http": patch
+---
+
+fix RouterBuilder.handle type arguments order

--- a/packages/effect-http/src/RouterBuilder.ts
+++ b/packages/effect-http/src/RouterBuilder.ts
@@ -146,7 +146,7 @@ export const handle: {
     id: Id,
     fn: Handler.Handler.Function<ApiEndpoint.ApiEndpoint.ExtractById<A, Id>, E2, R2>
   ): <R1, E1>(
-    builder: RouterBuilder<A, R1, E1>
+    builder: RouterBuilder<A, E1, R1>
   ) => RouterBuilder<
     ApiEndpoint.ApiEndpoint.ExcludeById<A, Id>,
     E1 | Exclude<E2, HttpError.HttpError>,


### PR DESCRIPTION
fix RouterBuilder.handle type arguments order