### PR TITLE
fix: swagger files type

### DIFF
--- a/.changeset/dull-hairs-press.md
+++ b/.changeset/dull-hairs-press.md
@@ -1,0 +1,6 @@
+---
+"effect-http-node": patch
+"effect-http": patch
+---
+
+Fix to read swagger files in proper format

--- a/packages/effect-http-node/src/internal/node-swagger-files.ts
+++ b/packages/effect-http-node/src/internal/node-swagger-files.ts
@@ -7,7 +7,7 @@ import * as Record from "effect/Record"
 import { getAbsoluteFSPath } from "swagger-ui-dist"
 
 /** @internal */
-const readFile = (path: string) => Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFileString(path, "utf-8"))
+const readFile = (path: string) => Effect.flatMap(FileSystem.FileSystem, (fs) => fs.readFile(path))
 
 /** @internal */
 const SWAGGER_FILE_NAMES = [
@@ -34,7 +34,7 @@ export const SwaggerFilesLive = Effect.gen(function*(_) {
   )
 
   const size = Object.entries(files).reduce(
-    (acc, [_, content]) => acc + content.length,
+    (acc, [_, content]) => acc + content.byteLength,
     0
   )
   const sizeMb = (size / 1024 / 1024).toFixed(1)

--- a/packages/effect-http/src/SwaggerRouter.ts
+++ b/packages/effect-http/src/SwaggerRouter.ts
@@ -13,7 +13,7 @@ import * as internal from "./internal/swagger-router.js"
  * @since 1.0.0
  */
 export interface SwaggerFiles {
-  files: Record<string, string>
+  files: Record<string, Uint8Array>
 }
 
 /**

--- a/packages/effect-http/src/internal/swagger-router.ts
+++ b/packages/effect-http/src/internal/swagger-router.ts
@@ -93,7 +93,7 @@ const serverStaticDocsFile = (filename: string, path?: HttpRouter.PathInput) => 
       const { files } = yield* _(SwaggerFiles)
       const content = files[filename]
 
-      return HttpServerResponse.text(content, {
+      return HttpServerResponse.raw(content, {
         headers: Headers.fromInput(headers)
       })
     })


### PR DESCRIPTION
Fixed a problem with png files not loading properly due to all swagger files being loaded as text.