### PR TITLE
Support handling FormData more like other request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Optional parameter is denoted using a question mark in the path
 match pattern. In the request param schema, use `Schema.optional(<schema>)`.
 
 In the following example the last `:another` path parameter can be
-ommited on the client side.
+omitted on the client side.
 
 ```typescript
 import { Schema } from "@effect/schema";
@@ -195,6 +195,29 @@ export const api = Api.make({ title: "My api" }).pipe(
 ```
 
 [\[Source code\]](./packages/effect-http-node/examples/request-validation-optional-parameter.ts)
+
+#### Form data
+
+When dealing with form data like file uploads, you can set separate client and server-side request bodies to take advantage of `@effect/platform`'s `Multipart.Persisted` handling.
+
+```typescript
+import { Schema } from "@effect/schema";
+import { pipe } from "effect";
+import { Api, Representation } from "effect-http";
+
+const api = pipe(
+  Api.make(),
+  Api.addEndpoint(
+    Api.post("upload", "/upload").pipe(
+      Api.formDataRequestBody, // Short for Api.setRequestBodies({server: Api.Persisted, client: Api.FormData})
+      Api.setResponseBody(Schema.String),
+      Api.setResponseRepresentations([Representation.plainText])
+    )
+  )
+);
+```
+
+[\[Source code\]](./packages/effect-http-node/examples/form-data.ts)
 
 ### Headers
 

--- a/packages/effect-http-node/test/testing-client.test.ts
+++ b/packages/effect-http-node/test/testing-client.test.ts
@@ -1,4 +1,4 @@
-import { FileSystem, HttpClientRequest, HttpRouter, HttpServerRequest } from "@effect/platform"
+import { FileSystem, HttpClientRequest, HttpRouter } from "@effect/platform"
 import { NodeContext } from "@effect/platform-node"
 import { Schema } from "@effect/schema"
 import * as it from "@effect/vitest"
@@ -216,17 +216,18 @@ it.scoped(
           Api.post("upload", "/upload").pipe(
             Api.setResponseBody(Schema.String),
             Api.setResponseRepresentations([Representation.plainText]),
-            Api.setRequestBody(ApiSchema.FormData)
+            Api.setRequestBodies({
+              server: ApiSchema.Persisted,
+              client: ApiSchema.FormData
+            })
           )
         )
       )
 
       const app = pipe(
         RouterBuilder.make(api),
-        RouterBuilder.handle("upload", () =>
+        RouterBuilder.handle("upload", ({ body }) =>
           Effect.gen(function*(_) {
-            const request = yield* _(HttpServerRequest.HttpServerRequest)
-            const body = yield* _(request.multipart)
             const file = body["file"]
 
             if (file === null) {

--- a/packages/effect-http/src/Api.ts
+++ b/packages/effect-http/src/Api.ts
@@ -7,6 +7,7 @@ import type * as Schema from "@effect/schema/Schema"
 import type * as Pipeable from "effect/Pipeable"
 import type * as Types from "effect/Types"
 
+import type { Multipart } from "@effect/platform"
 import type * as ApiEndpoint from "./ApiEndpoint.js"
 import type * as ApiGroup from "./ApiGroup.js"
 import * as ApiSchema from "./ApiSchema.js"
@@ -151,6 +152,11 @@ export {
    */
   delete,
   /**
+   * @category modifications
+   * @since 1.0.0
+   */
+  formDataRequestBody,
+  /**
    * @category constructors
    * @since 1.0.0
    */
@@ -185,6 +191,11 @@ export {
    * @since 1.0.0
    */
   setRequest,
+  /**
+   * @category modifications
+   * @since 1.0.0
+   */
+  setRequestBodies,
   /**
    * @category modifications
    * @since 1.0.0
@@ -252,6 +263,14 @@ export const setOptions: (
  * @since 1.0.0
  */
 export const FormData: Schema.Schema<FormData> = ApiSchema.FormData
+
+/**
+ * Multipart.Persisted schema
+ *
+ * @category schemas
+ * @since 1.0.0
+ */
+export const Persisted: Schema.Schema<Multipart.Persisted> = ApiSchema.Persisted
 
 /**
  * @category refinements

--- a/packages/effect-http/src/ApiEndpoint.ts
+++ b/packages/effect-http/src/ApiEndpoint.ts
@@ -10,6 +10,7 @@ import type * as Array from "effect/Array"
 import type * as Pipeable from "effect/Pipeable"
 import type * as Types from "effect/Types"
 
+import type { Multipart } from "@effect/platform"
 import type * as ApiRequest from "./ApiRequest.js"
 import type * as ApiResponse from "./ApiResponse.js"
 import type * as ApiSchema from "./ApiSchema.js"
@@ -262,11 +263,62 @@ export const setRequestBody: <B, R2>(
   Q,
   H,
   R1,
+  __,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1>, Response, Security>
-) => ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>, Response, Security> = internal.setRequestBody
+  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1, __>, Response, Security>
+) => ApiEndpoint<
+  Id,
+  ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, any>,
+  Response,
+  Security
+> = internal.setRequestBody
+
+/**
+ * @category modifications
+ * @since 1.0.0
+ */
+export const setRequestBodies: <B, C, R2>(schema: {
+  server: Schema.Schema<B, any, R2>
+  client: Schema.Schema<C, any, R2>
+}) => <
+  Id extends ApiEndpoint.AnyId,
+  _,
+  P,
+  Q,
+  H,
+  R1,
+  __,
+  Response extends ApiResponse.ApiResponse.Any,
+  Security extends Security.Security.Any
+>(
+  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1, __>, Response, Security>
+) => ApiEndpoint<
+  Id,
+  ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>,
+  Response,
+  Security
+> = internal.setRequestBodies
+
+export const formDataRequestBody: <
+  Id extends ApiEndpoint.AnyId,
+  _,
+  P,
+  Q,
+  H,
+  R1,
+  __,
+  Response extends ApiResponse.ApiResponse.Any,
+  Security extends Security.Security.Any
+>(
+  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1, __>, Response, Security>
+) => ApiEndpoint<
+  Id,
+  ApiRequest.ApiRequest<Multipart.Persisted, P, Q, H, R1, FormData>,
+  Response,
+  Security
+> = internal.formDataRequestBody
 
 /**
  * @category modifications
@@ -281,11 +333,12 @@ export const setRequestPath: <P, I extends Readonly<Record<string, string | unde
   Q,
   H,
   R1,
+  C,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<B, _, Q, H, R1>, Response, Security>
-) => ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>, Response, Security> = internal.setRequestPath
+  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<B, _, Q, H, R1, C>, Response, Security>
+) => ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>, Response, Security> = internal.setRequestPath
 
 /**
  * @category modifications
@@ -300,11 +353,12 @@ export const setRequestQuery: <Q, I extends Readonly<Record<string, string | und
   _,
   H,
   R1,
+  C,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, _, H, R1>, Response, Security>
-) => ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>, Response, Security> = internal.setRequestQuery
+  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, _, H, R1, C>, Response, Security>
+) => ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>, Response, Security> = internal.setRequestQuery
 
 /**
  * @category modifications
@@ -319,11 +373,12 @@ export const setRequestHeaders: <H, I extends Readonly<Record<string, string | u
   Q,
   _,
   R1,
+  C,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, _, R1>, Response, Security>
-) => ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>, Response, Security> = internal.setRequestHeaders
+  endpoint: ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, _, R1, C>, Response, Security>
+) => ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>, Response, Security> = internal.setRequestHeaders
 
 /**
  * @category modifications

--- a/packages/effect-http/src/ApiRequest.ts
+++ b/packages/effect-http/src/ApiRequest.ts
@@ -24,7 +24,7 @@ export type TypeId = typeof TypeId
  * @category models
  * @since 1.0.0
  */
-export interface ApiRequest<B, P, Q, H, R> extends ApiRequest.Variance<B, P, Q, H, R> {}
+export interface ApiRequest<B, P, Q, H, R, C> extends ApiRequest.Variance<B, P, Q, H, R, C> {}
 
 /**
  * @category models
@@ -35,13 +35,14 @@ export declare namespace ApiRequest {
    * @category models
    * @since 1.0.0
    */
-  export interface Variance<B, P, Q, H, R> {
+  export interface Variance<B, P, Q, H, R, C> {
     readonly [TypeId]: {
       readonly _B: Types.Invariant<B>
       readonly _P: Types.Invariant<P>
       readonly _Q: Types.Invariant<Q>
       readonly _H: Types.Invariant<H>
       readonly _R: Types.Covariant<R>
+      readonly _C: Types.Invariant<C>
     }
   }
 
@@ -51,7 +52,7 @@ export declare namespace ApiRequest {
    * @category models
    * @since 1.0.0
    */
-  export type Any = ApiRequest<any, any, any, any, any>
+  export type Any = ApiRequest<any, any, any, any, any, any>
 
   /**
    * Default request.
@@ -59,41 +60,54 @@ export declare namespace ApiRequest {
    * @category models
    * @since 1.0.0
    */
-  export type Default = ApiRequest<ApiSchema.Ignored, ApiSchema.Ignored, ApiSchema.Ignored, ApiSchema.Ignored, never>
+  export type Default = ApiRequest<
+    ApiSchema.Ignored,
+    ApiSchema.Ignored,
+    ApiSchema.Ignored,
+    ApiSchema.Ignored,
+    never,
+    ApiSchema.Ignored
+  >
 
   /**
    * @category models
    * @since 1.0.0
    */
-  export type Body<Request> = [Request] extends [ApiRequest<infer B, any, any, any, any>] ? B
+  export type Body<Request> = [Request] extends [ApiRequest<infer B, any, any, any, any, any>] ? B
     : never
 
   /**
    * @category models
    * @since 1.0.0
    */
-  export type Path<Request> = [Request] extends [ApiRequest<any, infer P, any, any, any>] ? P
+  export type ClientBody<Request> = [Request] extends [ApiRequest<any, any, any, any, any, infer C>] ? C : never
+
+  /**
+   * @category models
+   * @since 1.0.0
+   */
+  export type Path<Request> = [Request] extends [ApiRequest<any, infer P, any, any, any, any>] ? P
     : never
 
   /**
    * @category models
    * @since 1.0.0
    */
-  export type Query<Request> = [Request] extends [ApiRequest<any, any, infer Q, any, any>] ? Q
+  export type Query<Request> = [Request] extends [ApiRequest<any, any, infer Q, any, any, any>] ? Q
     : never
 
   /**
    * @category models
    * @since 1.0.0
    */
-  export type Headers<Request> = [Request] extends [ApiRequest<any, any, any, infer H, any>] ? H
+  export type Headers<Request> = [Request] extends [ApiRequest<any, any, any, infer H, any, any>] ? H
     : never
 
   /**
    * @category models
    * @since 1.0.0
    */
-  export type Context<Request> = [Request] extends [ApiRequest<any, any, any, any, infer R>] ? R
+  export type Context<Request> = [Request] extends [ApiRequest<any, any, any, any, infer R, any>] ? R
     : never
 }
 
@@ -101,32 +115,40 @@ export declare namespace ApiRequest {
  * @category getters
  * @since 1.0.0
  */
-export const getBodySchema: <B, P, Q, H, R>(
-  request: ApiRequest<B, P, Q, H, R>
+export const getBodySchema: <B, P, Q, H, R, C>(
+  request: ApiRequest<B, P, Q, H, R, C>
 ) => Schema.Schema<B, any, R> | ApiSchema.Ignored = internal.getBodySchema
 
 /**
  * @category getters
  * @since 1.0.0
  */
-export const getPathSchema: <B, P, Q, H, R>(
-  request: ApiRequest<B, P, Q, H, R>
+export const getClientBodySchema: <B, P, Q, H, R, C>(
+  request: ApiRequest<B, P, Q, H, R, C>
+) => Schema.Schema<C, any, R> | ApiSchema.Ignored = internal.getClientBodySchema
+
+/**
+ * @category getters
+ * @since 1.0.0
+ */
+export const getPathSchema: <B, P, Q, H, R, C>(
+  request: ApiRequest<B, P, Q, H, R, C>
 ) => Schema.Schema<P, any, R> | ApiSchema.Ignored = internal.getPathSchema
 
 /**
  * @category getters
  * @since 1.0.0
  */
-export const getQuerySchema: <B, P, Q, H, R>(
-  request: ApiRequest<B, P, Q, H, R>
+export const getQuerySchema: <B, P, Q, H, R, C>(
+  request: ApiRequest<B, P, Q, H, R, C>
 ) => Schema.Schema<Q, any, R> | ApiSchema.Ignored = internal.getQuerySchema
 
 /**
  * @category getters
  * @since 1.0.0
  */
-export const getHeadersSchema: <B, P, Q, H, R>(
-  request: ApiRequest<B, P, Q, H, R>
+export const getHeadersSchema: <B, P, Q, H, R, C>(
+  request: ApiRequest<B, P, Q, H, R, C>
 ) => Schema.Schema<H, any, R> | ApiSchema.Ignored = internal.getHeadersSchema
 
 /**
@@ -135,9 +157,20 @@ export const getHeadersSchema: <B, P, Q, H, R>(
  */
 export const setBody: <B, R2>(
   schema: Schema.Schema<B, any, R2>
-) => <_, P, Q, H, R1>(
-  endpoint: ApiRequest<_, P, Q, H, R1>
-) => ApiRequest<B, P, Q, H, R1 | R2> = internal.setBody
+) => <_, P, Q, H, R1, __>(
+  endpoint: ApiRequest<_, P, Q, H, R1, __>
+) => ApiRequest<B, P, Q, H, R1 | R2, B> = internal.setBody
+
+/**
+ * @category modifications
+ * @since 1.0.0
+ */
+export const setBodies: <B, C, R2>(schemas: {
+  server: Schema.Schema<B, any, R2>
+  client: Schema.Schema<C, any, R2>
+}) => <_, P, Q, H, R1, __>(
+  endpoint: ApiRequest<_, P, Q, H, R1, __>
+) => ApiRequest<B, P, Q, H, R1 | R2, C> = internal.setBodies
 
 /**
  * @category modifications
@@ -145,9 +178,9 @@ export const setBody: <B, R2>(
  */
 export const setPath: <P, R2>(
   schema: Schema.Schema<P, any, R2>
-) => <B, _, Q, H, R1>(
-  endpoint: ApiRequest<B, _, Q, H, R1>
-) => ApiRequest<B, P, Q, H, R1 | R2> = internal.setPath
+) => <B, _, Q, H, R1, C>(
+  endpoint: ApiRequest<B, _, Q, H, R1, C>
+) => ApiRequest<B, P, Q, H, R1 | R2, C> = internal.setPath
 
 /**
  * @category modifications
@@ -155,9 +188,9 @@ export const setPath: <P, R2>(
  */
 export const setQuery: <Q, R2>(
   schema: Schema.Schema<Q, any, R2>
-) => <B, P, _, H, R1>(
-  endpoint: ApiRequest<B, P, _, H, R1>
-) => ApiRequest<B, P, Q, H, R1 | R2> = internal.setQuery
+) => <B, P, _, H, R1, C>(
+  endpoint: ApiRequest<B, P, _, H, R1, C>
+) => ApiRequest<B, P, Q, H, R1 | R2, C> = internal.setQuery
 
 /**
  * @category modifications
@@ -165,6 +198,6 @@ export const setQuery: <Q, R2>(
  */
 export const setHeaders: <H, R2>(
   schema: Schema.Schema<H, any, R2>
-) => <B, P, Q, _, R1>(
-  endpoint: ApiRequest<B, P, Q, _, R1>
-) => ApiRequest<B, P, Q, H, R1 | R2> = internal.setHeaders
+) => <B, P, Q, _, R1, C>(
+  endpoint: ApiRequest<B, P, Q, _, R1, C>
+) => ApiRequest<B, P, Q, H, R1 | R2, C> = internal.setHeaders

--- a/packages/effect-http/src/ApiSchema.ts
+++ b/packages/effect-http/src/ApiSchema.ts
@@ -1,6 +1,7 @@
 /**
  * @since 1.0.0
  */
+import type { Multipart } from "@effect/platform"
 import type * as Schema from "@effect/schema/Schema"
 import * as internal from "./internal/api-schema.js"
 
@@ -43,3 +44,11 @@ export const isIgnored: (u: unknown) => u is Ignored = internal.isIgnored
  * @since 1.0.0
  */
 export const FormData: Schema.Schema<FormData> = internal.formDataSchema
+
+/**
+ * Multipart.Persisted schema
+ *
+ * @category schemas
+ * @since 1.0.0
+ */
+export const Persisted: Schema.Schema<Multipart.Persisted> = internal.persistedSchema

--- a/packages/effect-http/src/Client.ts
+++ b/packages/effect-http/src/Client.ts
@@ -46,7 +46,7 @@ export declare namespace Client {
    * @since 1.0.0
    */
   export type Function<E extends ApiEndpoint.ApiEndpoint.Any> = (
-    input: Handler.Handler.ToRequest<ApiEndpoint.ApiEndpoint.Request<E>>,
+    input: Handler.Handler.ToRequest<ApiEndpoint.ApiEndpoint.Request<E>, true>,
     map?: (request: HttpClientRequest.HttpClientRequest) => HttpClientRequest.HttpClientRequest
   ) => Effect.Effect<
     Handler.Handler.ToResponse<ApiEndpoint.ApiEndpoint.Response<E>>,

--- a/packages/effect-http/src/Handler.ts
+++ b/packages/effect-http/src/Handler.ts
@@ -112,8 +112,8 @@ export declare namespace Handler {
    * @category models
    * @since 1.0.0
    */
-  export type ToRequest<R extends ApiRequest.ApiRequest.Any> = utils.RemoveIgnoredFields<{
-    readonly body: ApiRequest.ApiRequest.Body<R>
+  export type ToRequest<R extends ApiRequest.ApiRequest.Any, IsClient = false> = utils.RemoveIgnoredFields<{
+    readonly body: IsClient extends true ? ApiRequest.ApiRequest.ClientBody<R> : ApiRequest.ApiRequest.Body<R>
     readonly path: ApiRequest.ApiRequest.Path<R>
     readonly query: ApiRequest.ApiRequest.Query<R>
     readonly headers: ApiRequest.ApiRequest.Headers<R>

--- a/packages/effect-http/src/internal/api-endpoint.ts
+++ b/packages/effect-http/src/internal/api-endpoint.ts
@@ -9,6 +9,7 @@ import * as Pipeable from "effect/Pipeable"
 import * as Predicate from "effect/Predicate"
 import * as Tuple from "effect/Tuple"
 
+import type { Multipart } from "@effect/platform"
 import type * as ApiEndpoint from "../ApiEndpoint.js"
 import * as ApiRequest from "../ApiRequest.js"
 import * as ApiResponse from "../ApiResponse.js"
@@ -110,17 +111,73 @@ export const setRequestBody = <B, R2>(
   Q,
   H,
   R1,
+  __,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1>, Response, Security>
-): ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>, Response, Security> => {
+  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1, __>, Response, Security>
+): ApiEndpoint.ApiEndpoint<
+  Id,
+  ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, B>,
+  Response,
+  Security
+> => {
   if (getMethod(endpoint) === "GET") {
     throw new Error(`GET ${getPath(endpoint)} (${getId(endpoint)}) cannot have a request body`)
   }
 
   return setRequest(ApiRequest.setBody(schema)(getRequest(endpoint)))(endpoint)
 }
+
+/** @internal */
+export const setRequestBodies = <B, C, R2>(schemas: {
+  server: Schema.Schema<B, any, R2>
+  client: Schema.Schema<C, any, R2>
+}) =>
+<
+  Id extends ApiEndpoint.ApiEndpoint.AnyId,
+  _,
+  P,
+  Q,
+  H,
+  R1,
+  __,
+  Response extends ApiResponse.ApiResponse.Any,
+  Security extends Security.Security.Any
+>(
+  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1, __>, Response, Security>
+): ApiEndpoint.ApiEndpoint<
+  Id,
+  ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>,
+  Response,
+  Security
+> => {
+  if (getMethod(endpoint) === "GET") {
+    throw new Error(`GET ${getPath(endpoint)} (${getId(endpoint)}) cannot have a request body`)
+  }
+
+  return setRequest(ApiRequest.setBodies(schemas)(getRequest(endpoint)))(endpoint)
+}
+
+/** @internal */
+export const formDataRequestBody = <
+  Id extends ApiEndpoint.ApiEndpoint.AnyId,
+  _,
+  P,
+  Q,
+  H,
+  R1,
+  __,
+  Response extends ApiResponse.ApiResponse.Any,
+  Security extends Security.Security.Any
+>(
+  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<_, P, Q, H, R1, __>, Response, Security>
+): ApiEndpoint.ApiEndpoint<
+  Id,
+  ApiRequest.ApiRequest<Multipart.Persisted, P, Q, H, R1, FormData>,
+  Response,
+  Security
+> => setRequestBodies({ server: ApiSchema.Persisted, client: ApiSchema.FormData })(endpoint)
 
 /** @internal */
 export const setRequestPath = <P, R2>(
@@ -133,11 +190,12 @@ export const setRequestPath = <P, R2>(
   Q,
   H,
   R1,
+  C,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, _, Q, H, R1>, Response, Security>
-): ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>, Response, Security> =>
+  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, _, Q, H, R1, C>, Response, Security>
+): ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>, Response, Security> =>
   setRequest(ApiRequest.setPath(schema)(getRequest(endpoint)))(endpoint)
 
 /** @internal */
@@ -151,11 +209,12 @@ export const setRequestQuery = <Q, R2>(
   _,
   H,
   R1,
+  C,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, _, H, R1>, Response, Security>
-): ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>, Response, Security> =>
+  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, _, H, R1, C>, Response, Security>
+): ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>, Response, Security> =>
   setRequest(ApiRequest.setQuery(schema)(getRequest(endpoint)))(endpoint)
 
 /** @internal */
@@ -169,13 +228,14 @@ export const setRequestHeaders = <H, R2>(
   Q,
   _,
   R1,
+  C,
   Response extends ApiResponse.ApiResponse.Any,
   Security extends Security.Security.Any
 >(
-  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, _, R1>, Response, Security>
+  endpoint: ApiEndpoint.ApiEndpoint<Id, ApiRequest.ApiRequest<B, P, Q, _, R1, C>, Response, Security>
 ): ApiEndpoint.ApiEndpoint<
   Id,
-  ApiRequest.ApiRequest<B, P, Q, H, R1 | R2>,
+  ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C>,
   Response,
   Security
 > => setRequest(ApiRequest.setHeaders(schema)(getRequest(endpoint)))(endpoint)

--- a/packages/effect-http/src/internal/api-request.ts
+++ b/packages/effect-http/src/internal/api-request.ts
@@ -19,18 +19,21 @@ export const variance = {
   /* c8 ignore next */
   _H: (_: any) => _,
   /* c8 ignore next */
-  _R: (_: never) => _
+  _R: (_: never) => _,
+  /* c8 ignore next */
+  _C: (_: any) => _
 }
 
 /** @internal */
-export class ApiRequestImpl<B, P, Q, H, R> implements ApiRequest.ApiRequest<B, P, Q, H, R> {
+export class ApiRequestImpl<B, P, Q, H, R, C> implements ApiRequest.ApiRequest<B, P, Q, H, R, C> {
   readonly [TypeId] = variance
 
   constructor(
     readonly body: Schema.Schema<B, any, R> | ApiSchema.Ignored,
     readonly path: Schema.Schema<P, any, R> | ApiSchema.Ignored,
     readonly query: Schema.Schema<Q, any, R> | ApiSchema.Ignored,
-    readonly headers: Schema.Schema<H, any, R> | ApiSchema.Ignored
+    readonly headers: Schema.Schema<H, any, R> | ApiSchema.Ignored,
+    readonly clientBody: Schema.Schema<C, any, R> | ApiSchema.Ignored
   ) {}
 
   pipe() {
@@ -44,71 +47,99 @@ export const defaultRequest: ApiRequest.ApiRequest.Default = new ApiRequestImpl(
   ApiSchema.Ignored,
   ApiSchema.Ignored,
   ApiSchema.Ignored,
+  ApiSchema.Ignored,
   ApiSchema.Ignored
 )
 
 /** @internal */
-export const getBodySchema = <B, P, Q, H, R>(
-  request: ApiRequest.ApiRequest<B, P, Q, H, R>
-): Schema.Schema<B, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R>).body
+export const getBodySchema = <B, P, Q, H, R, C>(
+  request: ApiRequest.ApiRequest<B, P, Q, H, R, C>
+): Schema.Schema<B, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R, C>).body
 
 /** @internal */
-export const getPathSchema = <B, P, Q, H, R>(
-  request: ApiRequest.ApiRequest<B, P, Q, H, R>
-): Schema.Schema<P, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R>).path
+export const getClientBodySchema = <B, P, Q, H, R, C>(
+  request: ApiRequest.ApiRequest<B, P, Q, H, R, C>
+): Schema.Schema<C, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R, C>).clientBody
 
 /** @internal */
-export const getQuerySchema = <B, P, Q, H, R>(
-  request: ApiRequest.ApiRequest<B, P, Q, H, R>
-): Schema.Schema<Q, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R>).query
+export const getPathSchema = <B, P, Q, H, R, C>(
+  request: ApiRequest.ApiRequest<B, P, Q, H, R, C>
+): Schema.Schema<P, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R, C>).path
 
 /** @internal */
-export const getHeadersSchema = <B, P, Q, H, R>(
-  request: ApiRequest.ApiRequest<B, P, Q, H, R>
-): Schema.Schema<H, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R>).headers
+export const getQuerySchema = <B, P, Q, H, R, C>(
+  request: ApiRequest.ApiRequest<B, P, Q, H, R, C>
+): Schema.Schema<Q, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R, C>).query
 
 /** @internal */
-export const setBody =
-  <B, R2>(schema: Schema.Schema<B, any, R2>) =>
-  <_, P, Q, H, R1>(request: ApiRequest.ApiRequest<_, P, Q, H, R1>): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2> =>
-    new ApiRequestImpl<B, P, Q, H, R1 | R2>(
-      schema,
-      getPathSchema(request),
-      getQuerySchema(request),
-      getHeadersSchema(request)
-    )
+export const getHeadersSchema = <B, P, Q, H, R, C>(
+  request: ApiRequest.ApiRequest<B, P, Q, H, R, C>
+): Schema.Schema<H, any, R> | ApiSchema.Ignored => (request as ApiRequestImpl<B, P, Q, H, R, C>).headers
 
 /** @internal */
-export const setPath = <P, R2>(schema: Schema.Schema<P, any, R2>) =>
-<B, _, Q, H, R1>(
-  request: ApiRequest.ApiRequest<B, _, Q, H, R1>
-): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2> =>
-  new ApiRequestImpl<B, P, Q, H, R1 | R2>(
-    getBodySchema(request),
+export const setBody = <B, R2>(schema: Schema.Schema<B, any, R2>) =>
+<_, P, Q, H, R1, __>(
+  request: ApiRequest.ApiRequest<_, P, Q, H, R1, __>
+): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, B> =>
+  new ApiRequestImpl<B, P, Q, H, R1 | R2, B>(
     schema,
+    getPathSchema(request),
     getQuerySchema(request),
-    getHeadersSchema(request)
+    getHeadersSchema(request),
+    schema
   )
 
 /** @internal */
-export const setQuery =
-  <Q, R2>(schema: Schema.Schema<Q, any, R2>) =>
-  <B, P, _, H, R1>(request: ApiRequest.ApiRequest<B, P, _, H, R1>): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2> =>
-    new ApiRequestImpl<B, P, Q, H, R1 | R2>(
-      getBodySchema(request),
-      getPathSchema(request),
-      schema,
-      getHeadersSchema(request)
-    )
+export const setBodies = <B, C, R2>(schemas: {
+  server: Schema.Schema<B, any, R2>
+  client: Schema.Schema<C, any, R2>
+}) =>
+<_, P, Q, H, R1, __>(
+  request: ApiRequest.ApiRequest<_, P, Q, H, R1, __>
+): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C> =>
+  new ApiRequestImpl<B, P, Q, H, R1 | R2, C>(
+    schemas.server,
+    getPathSchema(request),
+    getQuerySchema(request),
+    getHeadersSchema(request),
+    schemas.client
+  )
+
+/** @internal */
+export const setPath = <P, R2>(schema: Schema.Schema<P, any, R2>) =>
+<B, _, Q, H, R1, C>(
+  request: ApiRequest.ApiRequest<B, _, Q, H, R1, C>
+): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C> =>
+  new ApiRequestImpl<B, P, Q, H, R1 | R2, C>(
+    getBodySchema(request),
+    schema,
+    getQuerySchema(request),
+    getHeadersSchema(request),
+    getClientBodySchema(request)
+  )
+
+/** @internal */
+export const setQuery = <Q, R2>(schema: Schema.Schema<Q, any, R2>) =>
+<B, P, _, H, R1, C>(
+  request: ApiRequest.ApiRequest<B, P, _, H, R1, C>
+): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C> =>
+  new ApiRequestImpl<B, P, Q, H, R1 | R2, C>(
+    getBodySchema(request),
+    getPathSchema(request),
+    schema,
+    getHeadersSchema(request),
+    getClientBodySchema(request)
+  )
 
 /** @internal */
 export const setHeaders = <H, R2>(schema: Schema.Schema<H, any, R2>) =>
-<B, P, Q, _, R1>(
-  request: ApiRequest.ApiRequest<B, P, Q, _, R1>
-): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2> =>
-  new ApiRequestImpl<B, P, Q, H, R1 | R2>(
+<B, P, Q, _, R1, C>(
+  request: ApiRequest.ApiRequest<B, P, Q, _, R1, C>
+): ApiRequest.ApiRequest<B, P, Q, H, R1 | R2, C> =>
+  new ApiRequestImpl<B, P, Q, H, R1 | R2, C>(
     getBodySchema(request),
     getPathSchema(request),
     getQuerySchema(request),
-    schema // TODO: transform schema properties to lowercase
+    schema, // TODO: transform schema properties to lowercase
+    getClientBodySchema(request)
   )

--- a/packages/effect-http/src/internal/api-schema.ts
+++ b/packages/effect-http/src/internal/api-schema.ts
@@ -1,6 +1,7 @@
 import * as Schema from "@effect/schema/Schema"
 import * as Predicate from "effect/Predicate"
 
+import { Multipart } from "@effect/platform"
 import type * as ApiSchema from "../ApiSchema.js"
 import * as circular from "./circular.js"
 
@@ -14,6 +15,18 @@ export const Ignored: ApiSchema.Ignored = { [IgnoredId]: IgnoredId }
 
 /** @internal */
 export const formDataSchema = Schema.instanceOf(FormData).pipe(
+  circular.annotate(() => ({
+    type: "string",
+    format: "binary",
+    description: "Multipart form data"
+  }))
+)
+
+/** @internal */
+export const persistedSchema = Schema.Record({
+  key: Schema.String,
+  value: Schema.Union(Schema.String, Multipart.FilesSchema)
+}).pipe(
   circular.annotate(() => ({
     type: "string",
     format: "binary",

--- a/packages/effect-http/src/internal/clientRequestEncoder.ts
+++ b/packages/effect-http/src/internal/clientRequestEncoder.ts
@@ -68,7 +68,7 @@ const ignoredSchemaEncoder = (name: string) => (input: unknown) => {
 
 /** @internal */
 const createBodyEncoder = (endpoint: ApiEndpoint.ApiEndpoint.Any) => {
-  const schema = ApiRequest.getBodySchema(ApiEndpoint.getRequest(endpoint))
+  const schema = ApiRequest.getClientBodySchema(ApiEndpoint.getRequest(endpoint))
 
   if (ApiSchema.isIgnored(schema)) {
     return ignoredSchemaEncoder("body")

--- a/packages/effect-http/src/internal/clientResponseParser.ts
+++ b/packages/effect-http/src/internal/clientResponseParser.ts
@@ -36,7 +36,7 @@ export const create = (
 
   return make((response) =>
     Effect.gen(function*(_) {
-      yield* _(handleUnsucessful(response))
+      yield* _(handleUnsuccessful(response))
 
       if (!(response.status in statusToSchema)) {
         const allowedStatuses = Object.keys(statusToSchema)
@@ -77,7 +77,7 @@ export const create = (
 }
 
 /** @internal */
-const handleUnsucessful = Unify.unify(
+const handleUnsuccessful = Unify.unify(
   (response: HttpClientResponse.HttpClientResponse) => {
     if (response.status >= 300) {
       return response.json.pipe(

--- a/packages/effect-http/src/internal/open-api.ts
+++ b/packages/effect-http/src/internal/open-api.ts
@@ -101,7 +101,7 @@ export const make = (
 
       const request = ApiEndpoint.getRequest(endpoint)
 
-      const body = ApiRequest.getBodySchema(request)
+      const body = ApiRequest.getClientBodySchema(request)
       const headers = ApiRequest.getHeadersSchema(request)
       const path = ApiRequest.getPathSchema(request)
       const query = ApiRequest.getQuerySchema(request)


### PR DESCRIPTION
Add a new type parameter to ApiRequest, tracking the body type for the client creating the request. Add request-bodies setters that take both the server and client schemas. In the existing request-body setters, set the one given schema for both, matching existing behavior.

Add a Persisted schema alongside the FormData schema.

Add a formDataRequestBody convenience method, which calls setRequestBodies with Persisted for the server and FormData for the client.

Update the serverRequestParser to check for the Persisted schema, and implement that branch by grabbing the multipart from the HttpServerRequest. Leave around the FormData branch for backwards compatibility.

Update the form data test and example to use the new approach, taking the body in the callback arguments like the normal case.