### PR TITLE
update effect/platform repo link to the mono repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![download badge](https://img.shields.io/npm/dm/effect-http.svg)
 
 High-level declarative HTTP library for [Effect-TS](https://github.com/Effect-TS) built on top of
-[@effect/platform](https://github.com/effect-ts/platform).
+[@effect/platform](https://github.com/Effect-TS/effect/tree/main/packages/platform).
 
 - :star: **Client derivation**. Write the api specification once, get the type-safe client with runtime validation for free.
 - :rainbow: **OpenAPI derivation**. `/docs` endpoint with OpenAPI UI out of box.


### PR DESCRIPTION
The @effect/platform package is now located at https://github.com/Effect-TS/effect/tree/main/packages/platform

The seperate Effect-TS/platform repo is deprecated and in archive mode.

Update the link to reflect the up to date link.